### PR TITLE
use ruby 2.0.0

### DIFF
--- a/gh-publisher-scripts/example.travis.yml
+++ b/gh-publisher-scripts/example.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 1.9.3
+- 2.0.0
 script: /bin/bash gh-publisher-scripts/gh-publisher.sh
 before_install:
 - yes "" | sudo apt-add-repository ppa:texlive-backports/ppa


### PR DESCRIPTION
Apparently GitHub Pages was [recently upgraded](https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0) to Jekyll 3.0, which [requires](http://jekyllrb.com/docs/upgrading/2-to-3/) Ruby >= 2.0.0. GitHub sent me a friendly email with this info when my page failed to build, and this commit seems to fix it. 

Thanks for this tool by the way, it is sweet!
